### PR TITLE
Quote repo var for apt repo's other than ppa's

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Add duplicity ppa
-  apt_repository: repo={{ backup_duplicity_ppa }} update_cache=yes
+  apt_repository: repo='{{ backup_duplicity_ppa }}' update_cache=yes
 
 - name: Install dependencies
   apt: pkg={{item}}


### PR DESCRIPTION
The repo option should be quoted as noted in the docs: http://docs.ansible.com/apt_repository_module.html.

I had issues using the default ppa(not able to validate the SSL cert) and had to use the deb source URL instead.
