### PR TITLE
changed: exclude template

### DIFF
--- a/templates/exclude.j2
+++ b/templates/exclude.j2
@@ -1,3 +1,3 @@
-{% for exclude in item.exlude|default(backup_exclude) %}
+{% for exclude in item.exclude|default(backup_exclude) %}
 - {{exclude}}
 {% endfor %}


### PR DESCRIPTION
```
- typo mistake in exclude.j2 template. Rename item.exlude to item.exclude
```
