### PR TITLE
quick fix for default backup_postgres_port

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ backup_logrotate: yes           # Setup logs rotation
 # Posgresql
 backup_postgres_user: postgres
 backup_postgres_host: ""
-backup_postgres_port: 5432
+backup_postgres_port: "5432"
 
 # Mysql
 backup_mysql_user: mysql


### PR DESCRIPTION
quick fix for default backup_postgres_port

TASK: [Stouts.backup | backup-configure | Configure pre scripts] **************
fatal: [default] => {'msg': "TypeError: cannot concatenate 'str' and 'int' objects", 'failed': True}
fatal: [default] => {'msg': 'One or more items failed.', 'failed': True, 'changed': False, 'results': [{'msg': "TypeError: cannot concatenate 'str' and 'int' objects", 'failed': True}]}

FATAL: all hosts have already failed -- aborting