### PR TITLE
Add MongoDB authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ backup_postgres_host: ""
 backup_mysql_user: mysql
 backup_mysql_pass: ""
 
+# MongoDB
+backup_mongo_user: mongo
+backup_mongo_pass: ""
+backup_mongo_host: 127.0.0.1
+backup_mongo_port: 27017
+
 backup_profiles: []           # Setup backup profiles
                               # Ex. backup_profiles:
                               #       - name: www               # required param

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,12 @@ backup_postgres_port: 5432
 backup_mysql_user: mysql
 backup_mysql_pass: ""
 
+# MongoDB
+backup_mongo_user: mongo
+backup_mongo_pass: ""
+backup_mongo_host: 127.0.0.1
+backup_mongo_port: 27017
+
 backup_profiles: []           # Setup backup profiles
                               # Ex. backup_profiles:
                               #       - name: www               # required param

--- a/templates/pre.j2
+++ b/templates/pre.j2
@@ -17,7 +17,14 @@ mysqldump -u {{backup_mysql_user}} -p{{backup_mysql_pass}} $DBNAME  > ${WORKDIR}
 
 {% elif item.source.startswith('mongo://') %}
 
-mongodump --out $WORKDIR/dump
+{% if item.source == 'mongo://' %}
+# Dump all databases
+mongodump -u {{backup_mongo_user}} -p {{backup_mongo_pass}} -h {{backup_mongo_host}} --port {{backup_mongo_port}} --out $WORKDIR/dump
+{% else %}
+# Dump the passed database
+DBNAME={{item.source.split('/')[-1]}}
+mongodump -u {{backup_mongo_user}} -p {{backup_mongo_pass}} -h {{backup_mongo_host}} --port {{backup_mongo_port}} -d $DBNAME --out $WORKDIR/dump
+{% endif %}
 
 {% endif %}
 

--- a/templates/restore.j2
+++ b/templates/restore.j2
@@ -19,7 +19,15 @@ rm -rf $WORKDIR/dump
 
 {% elif item.source.startswith('mongo://') %}
 
-mongorestore --drop $WORKDIR/dump
+{% if item.source == 'mongo://' %}
+# Restore all databases
+mongorestore -u {{backup_mongo_user}} -p {{backup_mongo_pass}} -h {{backup_mongo_host}} --port {{backup_mongo_port}} --drop $WORKDIR/dump
+{% else %}
+# Restore the passed database
+DBNAME={{item.source.split('/')[-1]}}
+mongorestore -u {{backup_mongo_user}} -p {{backup_mongo_pass}} -h {{backup_mongo_host}} --port {{backup_mongo_port}} -d $DBNAME --drop $WORKDIR/dump
+{% endif %}
+
 rm -rf $WORKDIR/dump
 
 {% endif %}


### PR DESCRIPTION
As we needed to have authentication for MongoDB, we've figured these modifications could be handy:

```
# the following variables can be overridden: 
backup_mongo_user
backup_mongo_pass 
backup_mongo_host
backup_mongo_port
```