### PR TITLE
Add host variable for MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ backup_postgres_host: ""
 # Mysql
 backup_mysql_user: mysql
 backup_mysql_pass: ""
+backup_mysql_host: ""
 
 backup_profiles: []           # Setup backup profiles
                               # Ex. backup_profiles:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ backup_postgres_port: 5432
 # Mysql
 backup_mysql_user: mysql
 backup_mysql_pass: ""
+backup_mysql_host: ""
 
 backup_profiles: []           # Setup backup profiles
                               # Ex. backup_profiles:

--- a/templates/pre.j2
+++ b/templates/pre.j2
@@ -14,11 +14,11 @@ pg_dump -U {{backup_postgres_user}} {{ '-h ' + backup_postgres_host  if backup_p
 
 {% if item.source == 'mysql://' %}
 # Dump all databases
-mysqldump -u {{backup_mysql_user}} -p{{backup_mysql_pass}} --all-databases > ${WORKDIR}/dump
+mysqldump {{'--host=' + backup_mysql_host  if backup_mysql_host else ''}} -u {{backup_mysql_user}} -p{{backup_mysql_pass}} --all-databases > ${WORKDIR}/dump
 {% else %}
 # Dump the passed database
 DBNAME={{item.source.split('mysql://')[-1]}}
-mysqldump -u {{backup_mysql_user}} -p{{backup_mysql_pass}} $DBNAME  > ${WORKDIR}/dump
+mysqldump {{'--host=' + backup_mysql_host  if backup_mysql_host else ''}} -u {{backup_mysql_user}} -p{{backup_mysql_pass}} $DBNAME  > ${WORKDIR}/dump
 {% endif %}
 
 {% elif item.source.startswith('mongo://') %}

--- a/templates/restore.j2
+++ b/templates/restore.j2
@@ -15,11 +15,11 @@ rm -rf $WORKDIR/dump
 
 {% if item.source == 'mysql://' %}
 # Restore all databases
-mysql -u {{backup_mysql_user}} -p{{backup_mysql_pass}} < ${WORKDIR}/dump
+mysql {{'--host=' + backup_mysql_host  if backup_mysql_host else ''}} -u {{backup_mysql_user}} -p{{backup_mysql_pass}} < ${WORKDIR}/dump
 {% else %}
 # Restore the passed database
 DBNAME={{item.source.split('mysql://')[-1]}}
-mysql -u {{backup_mysql_user}} -p{{backup_mysql_pass}} $DBNAME  < ${WORKDIR}/dump
+mysql {{'--host=' + backup_mysql_host  if backup_mysql_host else ''}} -u {{backup_mysql_user}} -p{{backup_mysql_pass}} $DBNAME  < ${WORKDIR}/dump
 rm -rf $WORKDIR/dump
 {% endif %}
 


### PR DESCRIPTION
There is a `backup_postgresql_host` variable to add a host for configuring the backup, but there is no such a variable for MySQL. 

So, here is a `backup_mysql_host` to configure the host of a MySQL database.