### PR TITLE
optional backports duplicity under Debian and fix for GPG2

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ backup_profiles: []           # Setup backup profiles
 backup_gpg_key: disabled
 backup_gpg_pw: ""
 backup_gpg_opts: ''
+# Configuration lines to be thrown in gpg-agent.conf
+backup_gpg_agent_conf:
+  - line: "allow-loopback-pinentry"
+    regexp: "^allow-loopback-pinentry"
+# Configuration lines to be thrown in gpg.conf
+backup_gpg_home_conf:
+  - line: "use-agent"
+    regexp: "^use-agent"
+  - line: "pinentry-mode loopback"
+    regexp: "^pinentry-mode"
 
 # TARGET
 # syntax is

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,6 +104,6 @@ backup_exclude: [] # List of filemasks to exlude
 
 # on certain distros like jessie, utilize backports to get a newer version of
 # duplicity
-backup_modern_duplicty: false
+backup_modern_duplicity: false
 
 backup_debian_url: "deb http://ftp.debian.org/debian {{ansible_lsb.codename}}-backports main"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,3 +101,9 @@ backup_volsize: 50
 backup_verbosity: 3
 
 backup_exclude: [] # List of filemasks to exlude
+
+# on certain distros like jessie, utilize backports to get a newer version of
+# duplicity
+backup_modern_duplicty: false
+
+backup_debian_url: "deb http://ftp.debian.org/debian {{ansible_lsb.codename}}-backports main"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,16 @@ backup_profiles: []           # Setup backup profiles
 backup_gpg_key: disabled
 backup_gpg_pw: ""
 backup_gpg_opts: ''
+# Configuration lines to be thrown in gpg-agent.conf
+backup_gpg_agent_conf:
+  - line: "allow-loopback-pinentry"
+    regexp: "^allow-loopback-pinentry"
+# Configuration lines to be thrown in gpg.conf
+backup_gpg_home_conf:
+  - line: "use-agent"
+    regexp: "^use-agent"
+  - line: "pinentry-mode loopback"
+    regexp: "^pinentry-mode"
 
 # TARGET
 # syntax is

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -52,3 +52,18 @@
 
 - name: backup-configure | Configure logrotate
   template: src=logrotate.j2 dest=/etc/logrotate.d/backup owner=root group=root mode=0644
+
+- name: backup-configure | Detect gpg version
+  command: gpg --version
+  changed_when: False
+  register: gpg_version_results
+
+- name: backup-configure | Set gpg.conf under GPG2
+  lineinfile: dest="{{ansible_user_dir}}/.gnupg/gpg.conf" line="{{ item.line }}" regexp="{{ item.regexp }}" create=yes
+  with_items: "{{backup_gpg_home_conf}}"
+  when: "'gpg (GnuPG) 2' in gpg_version_results.stdout"
+
+- name: backup-configure | Set gpg-agent.conf under GPG2
+  lineinfile: dest="{{ansible_user_dir}}/.gnupg/gpg-agent.conf" line="{{ item.line }}" regexp="{{ item.regexp }}" create=yes
+  with_items: "{{backup_gpg_agent_conf}}"
+  when: "'gpg (GnuPG) 2' in gpg_version_results.stdout"

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -13,5 +13,14 @@
 - set_fact: backup_duplicity_pkg="{{backup_duplicity_pkg}}={{backup_duplicity_version}}"
   when: backup_duplicity_version
 
+- name: Ensure backports is installed for duplicity 7+
+  apt_repository:
+    repo: "{{ backup_debian_url }}"
+    update_cache: yes
+  register: backports_result
+  when: backup_modern_duplicity
+
 - name: Install duplicity
-  apt: pkg={{backup_duplicity_pkg}}
+  apt:
+    pkg: "{{backup_duplicity_pkg}}"
+    default_release: "{{ ansible_lsb.codename+'-backports' if not backports_result.skipped|default(false) else omit }}"

--- a/templates/conf.j2
+++ b/templates/conf.j2
@@ -20,13 +20,19 @@ GPG_PW_SIGN='{{item.gpg_pw_sign}}'
 {% endif %}
 GPG_OPTS='{{item.gpg_opts|default(backup_gpg_opts)}}'
 
-TARGET='{{item.target|default(backup_target)}}'
+{% set target = item.target|default(backup_target) %}
+TARGET='{{target}}'
+
+{% if target.startswith('s3://') %}
+{% set template_target_user = "export AWS_ACCESS_KEY_ID" %}
+{% set template_target_pass = "export AWS_SECRET_ACCESS_KEY" %}
+{% endif %}
 
 {% if item.target_user|default(backup_target_user) %}
-TARGET_USER='{{item.target_user|default(backup_target_user)}}'
+{{template_target_user|default("TARGET_USER")}}='{{item.target_user|default(backup_target_user)}}'
 {% endif %}
 {% if item.target_pass|default(backup_target_pass) %}
-TARGET_PASS='{{item.target_pass|default(backup_target_pass)}}'
+{{template_target_pass|default("TARGET_PASS")}}='{{item.target_pass|default(backup_target_pass)}}'
 {% endif %}
 
 {% if item.source.startswith('postgresql://') or item.source.startswith('mysql://') or item.source.startswith('mongo://') %}

--- a/templates/duply.sh.j2
+++ b/templates/duply.sh.j2
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 #
-###############################################################################
-#  duply (grown out of ftplicity), is a shell front end to duplicity that     #
-#  simplifies the usage by managing settings for backup jobs in profiles.     #
-#  It supports executing multiple commands in a batch mode to enable single   #
-#  line cron entries and executes pre/post backup scripts.                    #
-#  Since version 1.5.0 all duplicity backends are supported. Hence the name   #
-#  changed from ftplicity to duply.                                           #
-#  See http://duply.net or http://ftplicity.sourceforge.net/ for more info.   #
-#  (c) 2006 Christiane Ruetten, Heise Zeitschriften Verlag, Germany           #
-#  (c) 2008-2014 Edgar Soldin (changes since version 1.3)                     #
-###############################################################################
-#  LICENSE:                                                                   #
-#  This program is licensed under GPLv2.                                      #
-#  Please read the accompanying license information in gpl.txt.               #
-###############################################################################
+################################################################################
+#  duply (grown out of ftplicity), is a shell front end to duplicity that      #
+#  simplifies the usage by managing settings for backup jobs in profiles.      #
+#  It supports executing multiple commands in a batch mode to enable single    #
+#  line cron entries and executes pre/post backup scripts.                     #
+#  Since version 1.5.0 all duplicity backends are supported. Hence the name    #
+#  changed from ftplicity to duply.                                            #
+#  See http://duply.net or http://ftplicity.sourceforge.net/ for more info.    #
+#  (c) 2006 Christiane Ruetten, Heise Zeitschriften Verlag, Germany            #
+#  (c) 2008-2016 Edgar Soldin (changes since version 1.3)                      #
+################################################################################
+#  LICENSE:                                                                    #
+#  This program is licensed under GPLv2.                                       #
+#  Please read the accompanying license information in gpl.txt.                #
+################################################################################
 #  TODO/IDEAS/KNOWN PROBLEMS:
 #  - possibility to restore time frames (incl. deleted files)
 #    realizable by listing each backup and restore from
@@ -32,8 +32,75 @@
 #  - hint on install software if a piece is missing
 #  - import/export profile from/to .tgz function !!!
 #
-#
 #  CHANGELOG:
+#  2.0.1 (16.11.2016)
+#  - bugfix 104: Duply 2.0 sets wrong archive dir, --name always 'duply_'
+#
+#  2.0 (27.10.2016)
+#  made this a major version change, as we broke backward compatibility anyway
+#  (see last change in v1.10). got complaints that rightfully pointed out
+#  that should only come w/ a major version change. so, here we go ;)
+#  if your backend stops working w/ this version create a new profile and
+#  export the env vars needed as described in the comments of the conf file
+#  directly above the SOURCE setting.
+#  - making sure multi spaces in TARGET survive awk processing
+#  - new env var PROFILE exported to scripts
+#  - fix 102: expose a unique timestamp variable for pre/post scripts
+#    actually a featreq. exporting RUN_START nanosec unix timestamp
+#  - fix 101: GPG_AGENT_INFO is 'bogus' (thx Thomas Harning Jr.)
+#  - fix 96: duply cannot handle two consecutive spaces in paths
+#
+#  1.11.3 (29.5.2016)
+#  - fix wrong "WARNING: No running gpg-agent ..." when sign key was not set
+#
+#  1.11.2 (11.2.2016)
+#  - fix "gpg: unsafe" version print out
+#  - bugfix 91: v1.11 [r47] broke asymmetric encryption when using GPG_KEYS_ENC
+#  - bugfix 90: S3: TARGET_USER/PASS have no effect, added additional
+#    documentation about needed env vars to template conf file
+#
+#  1.11.1 (18.12.2015)
+#  - bugfix 89: "Duply has trouble with PYTHON-interpreter" on OSX homebrew
+#  - reverted duply's default PYTHON to 'python'
+#
+#  1.11 (24.11.2015)
+#  - remove obsolete --ssh-askpass routine
+#  - add PYTHON conf var to allow global override of used python interpreter
+#  - enforced usage of "python2" in PATH as default interpreter for internal
+#    use _and_ to run duplicity (setup.py changed the shebang to the fixed
+#    path /usr/bin/python until 0.7.05, which we circumvent this way)
+#  - featreq 36: support gpg-connect-agent as a means to detect if an agent is
+#    running (thx Thomas Harning Jr.), used gpg-agent for detection though
+#  - quotewrapped run_cmd parameters to protect it from spaces eg. in TMP path
+#  - key export routine respects gpg-agent usage now
+#
+#  1.10.1 (19.8.2015)
+#  - bugfix 86: Duply+Swift outputs warning
+#  - bugfix 87: Swift fails without BACKEND_URL
+#
+#  1.10 (31.7.2015)
+#  - featreq 37: busybox issues - fix awk, grep version detection,
+#    fix grep failure because --color=never switch is unsupported
+#    (thx Thomas Harning Jr. for reporting and helping to debug/fix it)
+#  - bugfix 81: --exclude-globbing-filelist is deprecated since 0.7.03
+#    (thx Joachim Wiedorn, also for maintaining the debian package)
+#  - implemented base-/dirname as bash functions
+#  - featreq 31 " Support for duplicity Azure backend " - ignored a
+#    contributed patch by Scott McKenzie and instead opted for removing almost
+#    all code that deals with special env vars required by backends.
+#    adding and modifying these results in too much overhead so i dropped this
+#    feature. the future alternative for users is to consult the duplicity
+#    manpage and add the needed export definitions to the conf file.
+#    appended a commented example to the template conf below the auth section.
+#
+#  1.9.2 (21.6.2015)
+#  - bugfix: exporting keys with gpg2.1 works now (thx Philip Jocks)
+#  - documented GPG_OPTS needed for gpg2.1 to conf template (thx Troy Engel)
+#  - bugfix 82: GREP_OPTIONS=--color=always disrupted time calculation
+#  - added GPG conf var (see conf template for details)
+#  - added grep version output as it is an integral needed binary
+#  - added PYTHONPATH printout in version output
+#
 #  1.9.1 (13.10.2014)
 #  - export CMD_ERR now for scripts to detect if CMD_PREV failed/succeeded
 #  - bugfix: CMD_PREV contained command even if it was skipped
@@ -358,15 +425,44 @@
 #    1.1.1 - bugfix: encryption reactivated
 #    1.1   - introduced config directory
 #    1.0   - first release
-###############################################################################
+################################################################################
 
+# utility functions overriding binaries
+
+# wrap grep to override possible env set GREP_OPTIONS=--color=always
+function grep {
+  command env -u GREP_OPTIONS grep "$@"
+}
+
+# implement basename in plain bash
+function basename {
+  echo "${1##*/}"
+}
+
+# implement dirname in plain bash
+function dirname {
+  echo ${1%/*}
+}
+
+# implement basic which in plain bash
+function which {
+  type -p "$@"
+}
+
+# check availability of executables via file name or file paths
+function lookup {
+  local bin="$1"
+  # look for file names in path via bash hash OR
+  # look for executables at given relative/absolute location
+  ( [ "${bin##*/}" == "$bin" ] && hash "$bin" 2>/dev/null ) || [ -x "$bin" ]
+}
 
 # important definitions #######################################################
 
 ME_LONG="$0"
 ME="$(basename $0)"
 ME_NAME="${ME%%.*}"
-ME_VERSION="1.9.1"
+ME_VERSION="2.0.1"
 ME_WEBSITE="http://duply.net"
 
 # default config values
@@ -374,15 +470,20 @@ DEFAULT_SOURCE='/path/of/source'
 DEFAULT_TARGET='scheme://user[:password]@host[:port]/[/]path'
 DEFAULT_TARGET_USER='_backend_username_'
 DEFAULT_TARGET_PASS='_backend_password_'
+DEFAULT_GPG='gpg'
 DEFAULT_GPG_KEY='_KEY_ID_'
 DEFAULT_GPG_PW='_GPG_PASSWORD_'
+DEFAULT_PYTHON='python'
 
 # function definitions ##########################
-function set_config { # sets config vars
+
+function set_config { # sets global config vars
   local CONFHOME_COMPAT="$HOME/.ftplicity"
   local CONFHOME_ETC_COMPAT="/etc/ftplicity"
   local CONFHOME_ETC="{{backup_home}}"
   local CONFHOME="{{backup_home}}"
+
+{% raw %}
 
   # confdir can be delivered as path (must contain /)
   if [ `echo $FTPLCFG | grep /` ] ; then
@@ -411,20 +512,17 @@ function set_config { # sets config vars
 
   # remove trailing slash, get profile name etc.
   CONFDIR="${CONFDIR%/}"
-  NAME="${CONFDIR##*/}"
+  PROFILE="${CONFDIR##*/}"
   CONF="$CONFDIR/conf"
   PRE="$CONFDIR/pre"
   POST="$CONFDIR/post"
   EXCLUDE="$CONFDIR/exclude"
   KEYFILE="$CONFDIR/gpgkey.asc"
-
 }
-
-{% raw %}
 
 function version_info { # print version information
   cat <<END
-  $ME version $ME_VERSION
+  $ME_NAME version $ME_VERSION
   ($ME_WEBSITE)
 END
 }
@@ -437,15 +535,24 @@ $(version_info)
 END
 }
 
+function python_binary {
+  echo "${PYTHON-$DEFAULT_PYTHON}"
+}
+
 function using_info {
-  duplicity_version_get
+  lookup duplicity && duplicity_version_get
+  local NOTFOUND="MISSING"
   # freebsd awk (--version only), debian mawk (-W version only), deliver '' so awk does not wait for input
-  AWK_VERSION=$((awk --version '' 2>/dev/null || awk -W version '' 2>/dev/null) | awk '/.+/{sub(/^[Aa][Ww][Kk][ \t]*/,"",$0);print $0;exit}')
-  PYTHON_VERSION=$(python -V 2>&1| awk '{print tolower($0);exit}')
-  GPG_INFO=`gpg --version 2>/dev/null| awk '/^gpg/{v=$1" "$3};/^Home/{print v" ("$0")"}'`
-  BASH_VERSION=$(bash --version | awk '/^GNU bash, version/{sub(/GNU bash, version[ ]+/,"",$0);print $0}')
-  echo -e "Using installed duplicity version ${DUPL_VERSION:-(not found)}${PYTHON_VERSION+, $PYTHON_VERSION}\
-${GPG_INFO:+, $GPG_INFO}${AWK_VERSION:+, awk '${AWK_VERSION}'}${BASH_VERSION:+, bash '${BASH_VERSION}'}."
+  local AWK_VERSION=$( lookup awk && (awk --version 2>/dev/null || awk -W version 2>&1) | awk 'NR<=2&&tolower($0)~/(busybox|awk)/{success=1;print;exit} END{if(success<1) print "unknown"}' || echo "$NOTFOUND" )
+  local GREP_VERSION=$( lookup grep && grep --version 2>&1 | awk 'NR<=2&&tolower($0)~/(busybox|grep.*[0-9]+\.[0-9]+)/{success=1;print;exit} END{if(success<1) print "unknown"}' || echo "$NOTFOUND" )
+  local PYTHON_RUNNER=$(python_binary)
+  local PYTHON_VERSION=$(lookup "$PYTHON_RUNNER" && "$PYTHON_RUNNER" -V 2>&1| awk '{print tolower($0);exit}' || echo "'$PYTHON_RUNNER' $NOTFOUND" )
+  local GPG_INFO=$(gpg_avail && gpg --version 2>&1| awk '/^gpg.*[0-9\.]+$/&&length(v)<1{v=$1" "$3}/^Home:/{h=" ("$0")"}END{print v""h}' || echo "gpg $NOTFOUND")
+  local BASH_VERSION=$(bash --version | awk 'NR==1{IGNORECASE=1;sub(/GNU bash, version[ ]+/,"",$0);print $0}')
+  echo -e "Using installed duplicity version ${DUPL_VERSION:-$NOTFOUND}\
+${PYTHON_VERSION+, $PYTHON_VERSION${PYTHONPATH:+ 'PYTHONPATH=$PYTHONPATH'}}\
+${GPG_INFO:+, $GPG_INFO}${AWK_VERSION:+, awk '${AWK_VERSION}'}${GREP_VERSION:+, grep '${GREP_VERSION}'}\
+${BASH_VERSION:+, bash '${BASH_VERSION}'}."
 }
 
 function usage_info { # print usage information
@@ -459,8 +566,9 @@ DESCRIPTION:
   It simplifies running duplicity with cron or on command line by:
 
     - keeping recurring settings in profiles per backup job
-    - enabling batch operations eg. backup_verify_purge
-    - executing pre/post scripts for every command
+    - enabling batch operations eg. backup_verify+purge
+    - executing pre/post scripts (different actions possible
+      depending on previous or next command or it's exit status)
     - precondition checking for flawless duplicity operation
 
   For each backup job one configuration profile must be created.
@@ -488,10 +596,10 @@ PROFILE:
   to '~/.${ME_NAME}/<profile>' (~ expands to environment variable \$HOME).
 
   Superuser root can place profiles under '/etc/${ME_NAME}'. Simply create
-  the folder manually before running $ME as superuser.
+  the folder manually before running $ME_NAME as superuser.
   Note:
-    Already existing profiles in root's profile folder will cease to work
-    unless there are moved to the new location manually.
+    Already existing profiles in root's home folder will cease to work
+    unless they are moved to the new location manually.
 
   example 1:   $ME humbug backup
 
@@ -561,7 +669,7 @@ COMMANDS:
   txt2man    feature for package maintainers - create a manpage based on the
              usage output. download txt2man from http://mvertes.free.fr/, put
              it in the PATH and run '$ME txt2man' to create a man page.
-  version    show version information of $ME and needed programs
+  version    show version information of $ME_NAME and needed programs
 
 OPTIONS:
   --force    passed to duplicity (see commands: purge, purge-full, cleanup)
@@ -581,8 +689,8 @@ PRE/POST SCRIPTS:
   Useful internal duply variables will be readable in the scripts.
   Some of interest may be
 
-    CONFDIR, SOURCE, TARGET_URL_<PROT|HOSTPATH|USER|PASS>,
-    GPG_<KEYS_ENC|KEY_SIGN|PW>, CMD_<PREV|NEXT>, CMD_ERR
+    PROFILE, CONFDIR, SOURCE, TARGET_URL_<PROT|HOSTPATH|USER|PASS>,
+    GPG_<KEYS_ENC|KEY_SIGN|PW>, CMD_<PREV|NEXT>, CMD_ERR, RUN_START
 
   The CMD_* variables were introduced to allow different actions according to
   the command the scripts were attached to e.g. 'pre_bkp_post_pre_verify_post'
@@ -592,12 +700,12 @@ PRE/POST SCRIPTS:
 
 EXAMPLES:
   create profile 'humbug':
-    $ME humbug create (now edit the resulting conf file)
+    $ME humbug create (don't forget to edit this new conf file)
   backup 'humbug' now:
     $ME humbug backup
   list available backup sets of profile 'humbug':
     $ME humbug status
-  list and delete obsolete backup archives of 'humbug':
+  list and delete outdated backups of 'humbug':
     $ME humbug purge --force
   restore latest backup of 'humbug' to /mnt/restore:
     $ME humbug restore /mnt/restore
@@ -606,6 +714,8 @@ EXAMPLES:
     (see "duplicity manpage", section TIME FORMATS)
   a one line batch job on 'humbug' for cron execution:
     $ME humbug backup_verify_purge --force
+  batch job to run a full backup with pre/post scripts:
+    $ME humbug pre_full_post
 
 FILES:
   in profile folder '~/.${ME_NAME}/<profile>' or '/etc/${ME_NAME}'
@@ -670,60 +780,60 @@ GPG_PW='${DEFAULT_GPG_PW}'
 # NOTE: available since duplicity 0.6.14, translates to SIGN_PASSPHRASE
 #GPG_PW_SIGN='<signpass>'
 
+# uncomment and set a file path or name force duply to use this gpg executable
+# available in duplicity 0.7.04 and above (currently unreleased 06/2015)
+#GPG='/usr/local/gpg-2.1/bin/gpg'
+
 # gpg options passed from duplicity to gpg process (default='')
 # e.g. "--trust-model pgp|classic|direct|always"
 #   or "--compress-algo=bzip2 --bzip2-compress-level=9"
 #   or "--personal-cipher-preferences AES256,AES192,AES..."
 #   or "--homedir ~/.duply" - keep keyring and gpg settings duply specific
+#   or "--pinentry-mode loopback" - needed for GPG 2.1+ _and_
+#      also enable allow-loopback-pinentry in your .gnupg/gpg-agent.conf
 #GPG_OPTS=''
 
 # disable preliminary tests with the following setting
 #GPG_TEST='disabled'
 
-# credentials & server address of the backup target (URL-Format)
-# syntax is
-#   scheme://[user:password@]host[:port]/[/]path
-# for details see duplicity manpage, section URL Format
-#   http://duplicity.nongnu.org/duplicity.1.html#sect8
-# probably one out of
-#   # for cloudfiles backend user id is CLOUDFILES_USERNAME, password is
-#   # CLOUDFILES_APIKEY, you might need to set CLOUDFILES_AUTHURL manually
-#   cf+http://[user:password@]container_name
-#   dpbx:///some_dir
-#   file://[relative|/absolute]/local/path
-#   ftp[s]://user[:password]@other.host[:port]/some_dir
-#   gdocs://user[:password]@other.host/some_dir
-#   # for the google cloud storage (since duplicity 0.6.22)
-#   # user/password are GS_ACCESS_KEY_ID/GS_SECRET_ACCESS_KEY
-#   gs://bucket[/prefix]
-#   hsi://user[:password]@other.host/some_dir
-#   imap[s]://user[:password]@host.com[/from_address_prefix]
-#   mega://user[:password]@mega.co.nz/some_dir
-#   rsync://user[:password]@host.com[:port]::[/]module/some_dir
-#   # rsync over ssh (only keyauth)
-#   rsync://user@host.com[:port]/[relative|/absolute]_path
-#   # for the s3 user/password are AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
-#   s3://[user:password@]host/bucket_name[/prefix]
-#   s3+http://[user:password@]bucket_name[/prefix]
-#   # scp and sftp are aliases for the ssh backend
-#   ssh://user[:password]@other.host[:port]/[/]some_dir
-#   # for authenticated swift define TARGET_USER or SWIFT_USERNAME,
-#   # TARGET_PASS or SWIFT_PASSWORD, SWIFT_AUTHURL (mandatory, the path to
-#   # your identity service, omitting leads to an error with swift),
-#   # optionally SWIFT_AUTHVERSION (which defaults to "1")
-#   swift://container_name
-#   tahoe://alias/directory
-#   webdav[s]://user[:password]@other.host/some_dir
-# ATTENTION: characters other than A-Za-z0-9.-_.~ in the URL have
-#            to be replaced by their url encoded pendants, see
-#            http://en.wikipedia.org/wiki/Url_encoding
-#            if you define the credentials as TARGET_USER, TARGET_PASS below
-#            duply will try to url_encode them for you if the need arises
+# backend, credentials & location of the backup target (URL-Format)
+# generic syntax is
+#   scheme://[user[:password]@]host[:port]/[/]path
+# eg.
+#   sftp://bob:secret@backupserver.com//home/bob/dupbkp
+# for details and available backends see duplicity manpage, section URL Format
+#   http://duplicity.nongnu.org/duplicity.1.html#sect7
+# BE AWARE:
+#   some backends (cloudfiles, S3 etc.) need additional env vars to be set to
+#   work properly, read after the TARGET definition for more details.
+# ATTENTION:
+#   characters other than A-Za-z0-9.-_.~ in the URL have to be
+#   replaced by their url encoded pendants, see
+#     http://en.wikipedia.org/wiki/Url_encoding
+#   if you define the credentials as TARGET_USER, TARGET_PASS below $ME
+#   will try to url_encode them for you if the need arises.
 TARGET='${DEFAULT_TARGET}'
 # optionally the username/password can be defined as extra variables
 # setting them here _and_ in TARGET results in an error
+# ATTENTION:
+#   there are backends that do not support the user/pass auth scheme.
+#   prominent examples are S3, Azure, Cloudfiles. when in doubt consult the
+#   duplicity manpage. usually there is a NOTE section explaining if and which
+#   env vars should be set.
 #TARGET_USER='${DEFAULT_TARGET_USER}'
 #TARGET_PASS='${DEFAULT_TARGET_PASS}'
+# eg. for cloud files backend it might look like this (uncomment for use!)
+#export CLOUDFILES_USERNAME='someuser'
+#export CLOUDFILES_APIKEY='somekey'
+#export CLOUDFILES_AUTHURL ='someurl'
+# the following is an incomplete list (<backend>: comma separated env vars list)
+# Azure: AZURE_ACCOUNT_NAME, AZURE_ACCOUNT_KEY
+# Cloudfiles: CLOUDFILES_USERNAME, CLOUDFILES_APIKEY, CLOUDFILES_AUTHURL
+# Google Cloud Storage: GS_ACCESS_KEY_ID, GS_SECRET_ACCESS_KEY
+# Pydrive: GOOGLE_DRIVE_ACCOUNT_KEY, GOOGLE_DRIVE_SETTINGS
+# S3: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+# Swift: SWIFT_USERNAME, SWIFT_PASSWORD, SWIFT_AUTHURL,
+#        SWIFT_TENANTNAME OR SWIFT_PREAUTHURL, SWIFT_PREAUTHTOKEN
 
 # base directory to backup
 SOURCE='${DEFAULT_SOURCE}'
@@ -732,6 +842,10 @@ SOURCE='${DEFAULT_SOURCE}'
 #  shape bandwidth use via trickle
 #  "trickle -s -u 640 -d 5120" # 5Mb up, 40Mb down"
 #DUPL_PRECMD=""
+
+# override the used python interpreter, defaults to "python"
+#   e.g. "python2" or "/usr/bin/python2.7"
+#PYTHON="python"
 
 # exclude folders containing exclusion file (since duplicity 0.5.14)
 # Uncomment the following two lines to enable this setting.
@@ -907,8 +1021,8 @@ function error_gpg_key {
   error_gpg "${KIND} gpg key '${KEY_ID}' cannot be found." \
 "Doublecheck if the above key is listed by 'gpg --list-keys' or available
   as gpg key file '$(basename "$(gpg_keyfile "${KEY_ID}")")' in the profile folder.
-  If not you can put it there and $ME will autoimport it on the next run.
-  Alternatively import it manually as the user you plan to run $ME with."
+  If not you can put it there and $ME_NAME will autoimport it on the next run.
+  Alternatively import it manually as the user you plan to run $ME_NAME with."
 }
 
 function error_gpg_test {
@@ -919,10 +1033,10 @@ function error_gpg_test {
 Hint${hint:+s}:
   ${hint}This error means that gpg is probably misconfigured or not working
   correctly. The error message above should help to solve the problem.
-  However, if for some reason $ME should misinterpret the situation you
+  However, if for some reason $ME_NAME should misinterpret the situation you
   can define GPG_TEST='disabled' in the conf file to bypass the test.
   Please do not forget to report the bug in order to resolve the problem
-  in future versions of $ME.
+  in future versions of $ME_NAME.
 "
 }
 
@@ -939,7 +1053,7 @@ function error_to_string {
 function duplicity_version_get {
 	var_isset DUPL_VERSION && return
 	DUPL_VERSION=`duplicity --version 2>&1 | awk '/^duplicity /{print $2; exit;}'`
-	#DUPL_VERSION='0.6.08b' #,0.4.4.RC4,0.6.08b
+	#DUPL_VERSION='0.7.03' #'0.6.08b' #,0.4.4.RC4,0.6.08b
 	DUPL_VERSION_VALUE=0
 	DUPL_VERSION_AWK=$(awk -v v="$DUPL_VERSION" 'BEGIN{
 	if (match(v,/[^\.0-9]+[0-9]*$/)){
@@ -959,7 +1073,7 @@ function duplicity_version_check {
 	if [ $DUPL_VERSION_VALUE -eq 0 ]; then
 		inform "duplicity version check failed (please report, this is a bug)"
 	elif [ $DUPL_VERSION_VALUE -le 404 ] && [ ${DUPL_VERSION_RC:-4} -lt 4 ]; then
-		error "The installed version $DUPL_VERSION is incompatible with $ME v$ME_VERSION.
+		error "The installed version $DUPL_VERSION is incompatible with $ME_NAME v$ME_VERSION.
 You should upgrade your version of duplicity to at least v0.4.4RC4 or
 use the older ftplicity version 1.1.1 from $ME_WEBSITE."
 	fi
@@ -1004,12 +1118,13 @@ function run_cmd {
   elif [ -n "$CMD_DISABLED" ]; then
     CMD_MSG="$CMD_MSG (DISABLED) - $CMD_DISABLED"
   else
+    echo -n -e "$CMD_MSG"
     CMD_OUT=` eval "$@" 2>&1 `
     CMD_ERR=$?
     if [ "$CMD_ERR" = "0" ]; then
-      CMD_MSG="$CMD_MSG (OK)"
+      CMD_MSG=" (OK)"
     else
-      CMD_MSG="$CMD_MSG (FAILED)"
+      CMD_MSG=" (FAILED)"
     fi
   fi
   echo -e "$CMD_MSG"
@@ -1057,7 +1172,7 @@ function duplicity_params_global {
     if var_isset 'ARCH_DIR'; then
       DUPL_ARCHDIR="--archive-dir $(qw "${ARCH_DIR}")"
     fi
-    DUPL_ARCHDIR="${DUPL_ARCHDIR} --name $(qw "duply_${NAME}")"
+DUPL_ARCHDIR="${DUPL_ARCHDIR} --name $(qw "duply_${PROFILE}")"
   fi
 
 DUPL_PARAMS_GLOBAL="${DUPL_ARCHDIR} ${DUPL_PARAM_ENC} \
@@ -1068,17 +1183,18 @@ DUPL_VARS_GLOBAL="TMPDIR='$TEMP_DIR' \
  ${DUPL_ARG_ENC}"
 }
 
-# filter the DUPL_PARAMS var from conf
-function duplicity_params_conf {
-	# reuse cmd var from main loop
-	## in/exclude parameters are currently not supported on restores
-	if [ "$cmd" = "fetch" ] || [ "$cmd" = "restore" ]; then
-		# filter exclude params from fetch/restore
-		echo "$DUPL_PARAMS" | awk '{gsub(/--(ex|in)clude[a-z-]*(([ \t]+|=)[^-][^ \t]+)?/,"");print}'
-		return
-	fi
 
-	echo "$DUPL_PARAMS"
+# function to filter the DUPL_PARAMS var from user conf
+function duplicity_params_conf {
+  # reuse cmd var from main loop
+  ## in/exclude parameters are currently not supported on restores
+  if [ "$cmd" = "fetch" ] || [ "$cmd" = "restore" ] || [ "$cmd" = "status" ]; then
+    # filter exclude params from fetch/restore
+    echo "$DUPL_PARAMS" | awk '{gsub(/--(ex|in)clude[a-z-]*(([ \t]+|=)[^-][^ \t]+)?/,"");print}'
+    return
+  fi
+
+  echo "$DUPL_PARAMS"
 }
 
 function duplify { # the actual wrapper function
@@ -1092,19 +1208,28 @@ function duplify { # the actual wrapper function
     else
       # wrap in quotes to protect from spaces
       [ ! $PARAMSNOW ] && \
-        DUPL_CMD="$DUPL_CMD $(qw $param)" \
+        DUPL_CMD="$DUPL_CMD $(qw "$param")" \
       || \
-        DUPL_CMD_PARAMS="$DUPL_CMD_PARAMS $(qw $param)"
+        DUPL_CMD_PARAMS="$DUPL_CMD_PARAMS $(qw "$param")"
     fi
   done
 
   # init global duplicity parameters same for all tasks
   duplicity_params_global
 
-  var_isset 'PREVIEW' && local RUN=echo || local RUN=eval
-$RUN ${DUPL_VARS_GLOBAL} ${BACKEND_PARAMS} \
- ${DUPL_PRECMD} duplicity $DUPL_CMD $DUPL_PARAMS_GLOBAL $(duplicity_params_conf)\
- $GPG_USEAGENT $DUPL_CMD_PARAMS ${PREVIEW:+}
+  local RUN=eval BIN=duplicity DUPL_BIN
+  # run in cmd line preview mode if requested
+  var_isset 'PREVIEW' && RUN=echo
+  # try to resolve duplicity path for usage with python interpreter
+  DUPL_BIN=$(which "$BIN") || DUPL_BIN="$BIN"
+  # only run with a user specific python if configured (running by default
+  # breaks homebrew as they place a shell wrapper for duplicity in path)
+  [ -n "$PYTHON" ] && [ "$PYTHON" != "$DEFAULT_PYTHON" ] &&\
+    BIN="$(qw "$(python_binary)") $(qw "$DUPL_BIN")"
+
+$RUN "${DUPL_VARS_GLOBAL} ${BACKEND_PARAMS} \
+${DUPL_PRECMD} $BIN $DUPL_CMD $DUPL_PARAMS_GLOBAL $(duplicity_params_conf)\
+ $GPG_USEAGENT $(gpg_custom_binary) $DUPL_CMD_PARAMS"
 
   local ERR=$?
   return $ERR
@@ -1135,7 +1260,7 @@ function date_fix {
 		echo $date && return
 	## some date commands do not support giving a time w/o setting it systemwide (irix,solaris,others?)
 	# python fallback
-	date=$(python -c "import time;print time.strftime('${1:-$DEFAULTFORMAT}',time.localtime(${2}))" 2> /dev/null) && \
+	date=$("$(python_binary)" -c "import time;print time.strftime('${1:-$DEFAULTFORMAT}',time.localtime(${2}))" 2> /dev/null) && \
 		echo $date && return
 	# awk fallback
 	date=$(awk "BEGIN{print strftime(\"${1:-$DEFAULTFORMAT}\"${2:+,$2})}" 2> /dev/null) && \
@@ -1181,7 +1306,7 @@ function var_isset {
 
 function url_encode {
   # utilize python, silently do nothing on error - because no python no duplicity
-  OUT=$(python -c "
+  OUT=$("$(python_binary)" -c "
 try: import urllib.request as urllib
 except ImportError: import urllib
 print(urllib.${2}quote('$1'));
@@ -1270,7 +1395,7 @@ function gpg_import {
       FOUND=1
 
       CMD_MSG="Import keyfile '$FILE' to keyring"
-      run_cmd "$GPG" $GPG_OPTS --batch --import "$FILE"
+      run_cmd gpg $GPG_OPTS --batch --import $(qw "$FILE")
       if [ "$?" != "0" ]; then
         warning "Import failed.${CMD_OUT:+\n$CMD_OUT}"
         ERR=1
@@ -1286,25 +1411,25 @@ function gpg_import {
 
   # try to set trust automagically
   CMD_MSG="Autoset trust of key '$KEY_ID' to ultimate"
-  run_cmd echo $(gpg_fingerprint "$KEY_ID"):6: \| "$GPG" $GPG_OPTS --import-ownertrust --batch --logger-fd 1
+  run_cmd echo $(gpg_fingerprint "$KEY_ID"):6: \| gpg $GPG_OPTS --import-ownertrust --batch --logger-fd 1
   if [ "$?" = "0" ] && [ -z "$PREVIEW" ]; then
    # success on all levels, we're done
    return $ERR
   fi
 
   # failover: user has to set trust manually
-  echo -e "For $ME to work you have to set the trust level
+  echo -e "For $ME_NAME to work you have to set the trust level
 with the command \"trust\" to \"ultimate\" (5) now.
 Exit the edit mode of gpg with \"quit\"."
   CMD_MSG="Running gpg to manually edit key '$KEY_ID'"
-  run_cmd sleep 5\; "$GPG" $GPG_OPTS --edit-key "$KEY_ID"
+  run_cmd sleep 5\; gpg $GPG_OPTS --edit-key $(qw "$KEY_ID")
 
   return $ERR
 }
 
 # see 'How to specify a user ID' on gpg manpage
 function gpg_fingerprint {
-  local PRINT=$("$GPG" $GPG_OPTS --fingerprint "$1" 2>&1|awk -F= 'NR==2{gsub(/ /,"",$2);$2=toupper($2); if ( $2 ~ /^[A-F0-9]+$/ && length($2) == 40 ) print $2; else exit 1}') \
+  local PRINT=$(gpg $GPG_OPTS --fingerprint "$1" 2>&1|awk -F= 'NR==2{gsub(/ /,"",$2);$2=toupper($2); if ( $2 ~ /^[A-F0-9]+$/ && length($2) == 40 ) print $2; else exit 1}') \
     && [ -n "$PRINT" ] && echo $PRINT && return 0
   return 1
 }
@@ -1318,13 +1443,15 @@ function gpg_export_if_needed {
       FILE="$(gpg_keyfile "$KEY_ID" $KEY_TYPE)"
       if [ ! -f "$FILE" ] && eval gpg_$(tolower $KEY_TYPE)_avail \"$KEY_ID\"; then
         # exporting
-        CMD_MSG="Export $KEY_TYPE key '$KEY_ID'"
-        run_cmd $GPG $GPG_OPTS --armor --export"$(test "SEC" = "$KEY_TYPE" && echo -secret-keys)"" $(qw $KEY_ID) >> \"$TMPFILE\""
+        CMD_MSG="Backup $KEY_TYPE key '$KEY_ID' to profile."
+        # gpg2.1 insists on passphrase here, gpg2.0- happily exports w/o it
+        # we pipe an empty string when GPG_PW is not set to avoid gpg silently waiting for input
+        run_cmd $(gpg_pass_pipein GPG_PW_SIGN GPG_PW) gpg $GPG_OPTS $GPG_USEAGENT $(gpg_param_passwd GPG_PW_SIGN GPG_PW) --armor --export"$(test "SEC" = "$KEY_TYPE" && echo -secret-keys)" $(qw "$KEY_ID") '>>' $(qw "$TMPFILE")
         CMD_ERR=$?
 
         if [ "$CMD_ERR" = "0" ]; then
           CMD_MSG="Write file '"$(basename "$FILE")"'"
-          run_cmd " mv \"$TMPFILE\" \"$FILE\""
+          run_cmd mv $(qw "$TMPFILE") $(qw "$FILE")
         fi
 
         if [ "$CMD_ERR" != "0" ]; then
@@ -1334,12 +1461,12 @@ function gpg_export_if_needed {
         fi
 
         # cleanup
-        rm "$TMPFILE" 1>/dev/null 2>&1
+        rm $(qw "$TMPFILE") 1>/dev/null 2>&1
       fi
     done
   done
 
-  [ -n "$SUCCESS" ] && inform "$ME exported new keys to your profile.
+  [ -n "$SUCCESS" ] && inform "$ME_NAME exported new keys to your profile.
 You should backup your changed profile folder now and store it in a safe place."
 }
 
@@ -1361,9 +1488,9 @@ function gpg_key_cache {
     return 255
   elif ! var_isset "$CACHE"; then
     if [ "$MODE" = "PUB" ]; then
-      RES=$("$GPG" $GPG_OPTS --list-key "$KEYID" > /dev/null 2>&1; echo -n $?)
+      RES=$(gpg $GPG_OPTS --list-key "$KEYID" > /dev/null 2>&1; echo -n $?)
     elif [ "$MODE" = "SEC" ]; then
-      RES=$("$GPG" $GPG_OPTS --list-secret-key "$KEYID" > /dev/null 2>&1; echo -n $?)
+      RES=$(gpg $GPG_OPTS --list-secret-key "$KEYID" > /dev/null 2>&1; echo -n $?)
     else
       return 255
     fi
@@ -1384,13 +1511,8 @@ function gpg_key_format {
   echo $1 | grep -q '^[0-9a-fA-F]\{8\}$'
 }
 
-#function gpg_split_keyset {
-#  return
-#  awk "BEGIN{ keys=toupper(\"$@\"); gsub(/[^A-Z0-9]/,\" \",keys); print keys }"
-#}
-
 # splits a comma separated line into lines, respects escaped commas
-function gpg_split_keyset2 {
+function gpg_split_keyset {
   local LIST
   LIST=$(echo "$@" | awk '{ gsub(/,/,"\n",$0); gsub(/\\\n/,",",$0); print $0 }')
   echo -e "$LIST"
@@ -1453,17 +1575,47 @@ function gpg_pass_pipein {
 
 # checks if gpg-agent is available, returns error code
 # 0 on success
-# 1 if GPG_AGENT_INFO is not set
+# 1 if GPG_AGENT_INFO is not set (unused, should probably be merged w/ 3)
 # 2 if GPG_AGENT_INFO is stale
+# 3 cannot connect to gpg-agent
 function gpg_agent_avail {
-  local ERR=1
+  # GPG_AGENT_INFO is deprecated in gpg2.1,
+  # first try to connect to a possibly running agent here
+  local ERR=3
+  gpg-agent > /dev/null 2>&1 && return 0
+
+  # detect stale pid in legacy GPG_AGENT_INFO env var
   if var_isset GPG_AGENT_INFO; then
-    ps -p $(echo $GPG_AGENT_INFO|awk -F: '{print $2}') > /dev/null 2>&1  &&\
-    ERR=0 || ERR=2
+    # check if a pid matching process is running at all
+    local GPG_AGENT_PID=$(echo $GPG_AGENT_INFO|awk -F: '{print $2}')
+    if isnumber "$GPG_AGENT_PID"; then
+      ps -p "$GPG_AGENT_PID" > /dev/null 2>&1 || ERR=2
+    fi
   fi
 
   return $ERR
 }
+
+function gpg_custom_binary {
+  var_isset GPG && [ "$GPG" != "$DEFAULT_GPG" ] &&\
+    echo "--gpg-binary $(qw "$GPG")"
+}
+
+function gpg_binary {
+  local BIN
+  var_isset GPG && BIN="$GPG" || BIN="$DEFAULT_GPG"
+  echo "$BIN"
+}
+
+function gpg_avail {
+  lookup "$(gpg_binary)"
+}
+
+# enforce the use our selected gpg binary
+function gpg {
+  command "$(gpg_binary)" "$@"
+}
+export -f gpg
 
 # start of script #######################################################################
 
@@ -1474,9 +1626,9 @@ umask 077
 [ -n "$ME_LONG" ] && [ -x "$ME_LONG" ] || error "$ME missing. Executable & available in path? ($ME_LONG)"
 
 if [ ${#@} -eq 1 ]; then
-	cmd="${1}"
+  cmd="${1}"
 else
-	FTPLCFG="${1}" ; cmd="${2}"
+  FTPLCFG="${1}" ; cmd="${2}"
 fi
 
 # deal with command before profile validation calls
@@ -1516,6 +1668,11 @@ Hint:
     exit 0
     ;;
   version|-version|--version|-v|-V)
+    # profile can override GPG, so import it if it was given
+    var_isset FTPLCFG && {
+      set_config
+      [ -r "$CONF" ] && . "$CONF" || warning "Cannot import config '$CONF'."
+    }
     version_info_using
     exit 0
     ;;
@@ -1539,13 +1696,18 @@ esac
 echo "Start $ME v$ME_VERSION, time is $(date_fix '%F %T')."
 
 # check system environment
-DUPLICITY="$(which duplicity 2>/dev/null)"
-[ -z "$DUPLICITY" ] && error_path "duplicity missing. installed und available in path?"
+
+# is duplicity avail
+lookup duplicity || error_path "duplicity missing. installed und available in path?"
 # init, exec duplicity version check info
 duplicity_version_get
 duplicity_version_check
 
-[ -z "$(which awk 2>/dev/null)" ] && error_path "awk missing. installed und available in path?"
+# check for certain important helper programs
+for f in awk grep "$(python_binary)"; do
+  lookup "$f" || \
+    error_path "$f missing. installed und available in path?"
+done
 
 ### read configuration
 set_config
@@ -1583,7 +1745,7 @@ echo "Using profile '$CONFDIR'."
 secureconf
 
 # split TARGET in handy variables
-TARGET_SPLIT_URL=$(echo $TARGET | awk '{ \
+TARGET_SPLIT_URL=$(echo "$TARGET" | awk '{ \
   target=$0; match(target,/^([^\/:]+):\/\//); \
   prot=substr(target,RSTART,RLENGTH);\
   rest=substr(target,RSTART+RLENGTH); \
@@ -1610,13 +1772,7 @@ TARGET_SPLIT_URL=$(echo $TARGET | awk '{ \
      gsub(/[\047]/,"\047\\\047\047",pass);\
      print "TARGET_URL_PASS=$(url_decode \047"pass"\047)\n"}\
   }')
-eval ${TARGET_SPLIT_URL}
-
-# check if backend specific software is in path
-[ -n "$(echo ${TARGET_URL_PROT} | grep -i -e '^ftp://$')" ] && \
-  [ -z "$(which ncftp 2>/dev/null)" ] && error_path "Protocol 'ftp' needs ncftp. Installed und available in path?"
-[ -n "$(echo ${TARGET_URL_PROT} | grep -i -e '^ftps://$')" ] && \
-  [ -z "$(which lftp 2>/dev/null)" ] && error_path "Protocol 'ftps' needs lftp. Installed und available in path?"
+eval "${TARGET_SPLIT_URL}"
 
 # fetch commmand from parameters ########################################################
 # Hint: cmds is also used to check if authentification info sufficient in the next step
@@ -1687,32 +1843,6 @@ elif var_isset 'TARGET_PASS' && var_isset 'TARGET_URL_PASS' && \
  Hint: Remove conflicting setting."
 fi
 
-# check if authentication information sufficient
-if ( ( ! var_isset 'TARGET_USER' && ! var_isset 'TARGET_URL_USER' ) && \
-       ( ! var_isset 'TARGET_PASS' && ! var_isset 'TARGET_URL_PASS' ) ); then
-  # ok here some exceptions:
-  #   protocols that do not need passwords
-  #   s3[+http] only needs password for write operations
-  if [ -n "$( tolower "${TARGET_URL_PROT}" | grep -e '^\(dpbx\|file\|tahoe\|ssh\|scp\|sftp\|swift\)://$' )" ]; then
-    : # all is well file/tahoe do not need passwords, ssh might use key auth
-  elif [ -n "$(tolower "${TARGET_URL_PROT}" | grep -e '^s3\(\+http\)\?://$')" ] && \
-     [ -z "$(echo ${cmds} | grep -e '\(bkp\|incr\|full\|purge\|cleanup\)')" ]; then
-    : # still fine, it's possible to read only access configured buckets anonymously
-  else
-    error " Backup target credentials needed but not set in conf file
- '$CONF'.
- Setting TARGET_USER or TARGET_PASS or the corresponding values in TARGET url
- are missing. Some protocols only might need it for write access to the backup
- repository (commands: bkp,backup,full,incr,purge) but not for read only access
- (e.g. verify,list,restore,fetch).
-
- Hints:
-   Add the credentials (user,password) to the conf file.
-   To force an empty password set TARGET_PASS='' or TARGET='prot://user:@host..'.
-"
-  fi
-fi
-
 # GPG config plausibility check1 (disabled check) #############################
 if gpg_disabled; then
   : # encryption disabled, all is well
@@ -1729,20 +1859,21 @@ fi
 
 # GPG availability check (now we know if gpg is really needed)#################
 if ! gpg_disabled; then
-	GPG="$(which gpg 2>/dev/null)"
-	[ -z "$GPG" ] && error_path "gpg missing. installed und available in path?"
+  gpg_avail || error_path "gpg '$(gpg_binary)' missing. installed und available in path?"
 fi
-
 
 # Output versions info ########################################################
 using_info
 
 # GPG create key settings, config check2 (needs gpg) ##########################
 if gpg_disabled; then
-	: # the following tests are not necessary
+  : # the following tests are not necessary
 else
 
-# key set?
+# we test this early as any invocation gpg2.1+ starts gpg-agent automatically
+GPG_AGENT_ERR=$(gpg_agent_avail ; echo $?)
+
+# enc key still default?
 if [ "$GPG_KEY" == "${DEFAULT_GPG_KEY}" ]; then
   error_gpg "Encryption Key GPG_KEY still default in conf file
 '$CONF'."
@@ -1750,8 +1881,29 @@ fi
 
 # create array of gpg encr keys, for further processing
 OIFS="$IFS" IFS=$'\n'
-GPG_KEYS_ENC_ARRAY=( $( gpg_split_keyset2 ${GPG_KEY},${GPG_KEYS_ENC} ) )
+GPG_KEYS_ENC_ARRAY=( $( gpg_split_keyset ${GPG_KEY},${GPG_KEYS_ENC} ) )
 IFS="$OIFS"
+
+# pw set?
+# symmetric needs one, always
+if gpg_symmetric && ( [ -z "$GPG_PW" ] || [ "$GPG_PW" == "${DEFAULT_GPG_PW}" ] ) \
+  ; then
+  error_gpg "Encryption passphrase GPG_PW (needed for symmetric encryption)
+is empty/not set or still default value in conf file
+'$CONF'."
+fi
+# this is a technicality, we can only pump one pass via pipe into gpg
+# but symmetric already always needs one for encryption
+if gpg_symmetric && var_isset GPG_PW && var_isset GPG_PW_SIGN &&\
+  [ -n "$GPG_PW_SIGN" ] && [ "$GPG_PW" != "$GPG_PW_SIGN" ]; then
+  error_gpg "GPG_PW _and_ GPG_PW_SIGN are defined but not identical in config
+'$CONF'.
+This is unfortunately impossible. For details see duplicity manpage,
+section 'A Note On Symmetric Encryption And Signing'.
+
+Tip: Separate signing keys may have empty passwords e.g. GPG_PW_SIGN=''.
+Tip2: Use gpg-agent."
+fi
 
 # check gpg encr public keys availability
 for (( i = 0 ; i < ${#GPG_KEYS_ENC_ARRAY[@]} ; i++ )); do
@@ -1805,26 +1957,7 @@ else
   fi
 fi
 
-# pw set?
-# symmetric needs one, always
-if gpg_symmetric && ( [ -z "$GPG_PW" ] || [ "$GPG_PW" == "${DEFAULT_GPG_PW}" ] ) \
-  ; then
-  error_gpg "Encryption passphrase GPG_PW (needed for symmetric encryption)
-is empty/not set or still default value in conf file
-'$CONF'."
-fi
-# this is a technicality, we can only pump one pass via pipe into gpg
-# but symmetric already always needs one for encryption
-if gpg_symmetric && var_isset GPG_PW && var_isset GPG_PW_SIGN &&\
-  [ -n "$GPG_PW_SIGN" ] && [ "$GPG_PW" != "$GPG_PW_SIGN" ]; then
-  error_gpg "GPG_PW _and_ GPG_PW_SIGN are defined but not identical in config
-'$CONF'.
-This is unfortunately impossible. For details see duplicity manpage,
-section 'A Note On Symmetric Encryption And Signing'.
-
-Tip: Separate signing keys may have empty passwords e.g. GPG_PW_SIGN=''.
-Tip2: Use gpg-agent."
-fi
+# using GPG_AGENT_ERR set early above, try to autoenable gpg-agent or issue some warnings
 # key enc can deal without, but might profit from gpg-agent
 # if GPG_PW is not set alltogether
 # if signing key is different from first (main) enc key (we can only pipe one pass into gpg)
@@ -1832,13 +1965,14 @@ if ! gpg_symmetric && \
    ( ! var_isset GPG_PW || \
      ( gpg_signing && ! var_isset GPG_PW_SIGN && [ "$GPG_KEY_SIGN" != "${GPG_KEYS_ENC_ARRAY[0]}" ] ) ); then
 
-  GPG_AGENT_ERR=$(gpg_agent_avail ; echo $?)
   if [ "$GPG_AGENT_ERR" -eq 1 ]; then
-    echo "Cannot use gpg-agent. GPG_AGENT_INFO not set."
+    warning "Cannot use gpg-agent. GPG_AGENT_INFO not set."
   elif [ "$GPG_AGENT_ERR" -eq 2 ]; then
-    echo "Cannot use gpg-agent! GPG_AGENT_INFO contains stale pid."
+    warning "Cannot use gpg-agent! GPG_AGENT_INFO contains stale pid."
+  elif [ "$GPG_AGENT_ERR" -eq 3 ]; then
+    warning "No running gpg-agent found although GPG_PW or GPG_PW_SIGN (enc != sign key) not set."
   else
-    echo "Autoenable use of gpg-agent. GPG_PW or GPG_PW_SIGN (enc != sign key) not set."
+    echo "Enable gpg-agent usage. Running gpg-agent instance found and GPG_PW or GPG_PW_SIGN (enc != sign key) not set."
     GPG_USEAGENT="--use-agent"
   fi
 fi
@@ -1848,17 +1982,11 @@ fi
 
 # config plausibility check - SPACE ###########################################
 
-# is tmp is a folder
-CMD_MSG="Checking TEMP_DIR '${TEMP_DIR}' is a folder"
-run_cmd test -d "$TEMP_DIR"
+# is tmp is a folder and writable
+CMD_MSG="Checking TEMP_DIR '${TEMP_DIR}' is a folder and writable"
+run_cmd test -d $(qw "$TEMP_DIR") '&&' test -w $(qw "$TEMP_DIR")
 if [ "$?" != "0" ]; then
-    error "Temporary file space '$TEMP_DIR' is not a directory."
-fi
-# is tmp writeable
-CMD_MSG="Checking TEMP_DIR '${TEMP_DIR}' is writable"
-run_cmd test -w "$TEMP_DIR"
-if [ "$?" != "0" ]; then
-    error "Temporary file space '$TEMP_DIR' not writable."
+    error "Temporary file space '$TEMP_DIR' is not a directory or writable."
 fi
 
 
@@ -1869,7 +1997,7 @@ echo $@ $DUPL_PARAMS | grep -q -e '--asynchronous-upload' && FACTOR=2 || FACTOR=
 
 # TODO: check for enough (async= upload space and WARN only
 #       use function tmp_space
-echo TODO: reimplent tmp space check
+#echo TODO: reimplent tmp space check
 
 
 # test - GPG SANITY #####################################################################
@@ -1883,7 +2011,7 @@ else
 GPG_TEST="$TEMP_DIR/${ME_NAME}.$$.$(date_fix %s)"
 function cleanup_gpgtest {
   echo -en "Cleanup - Delete '${GPG_TEST}_*'"
-  rm ${GPG_TEST}_* 2>/dev/null && echo "(OK)" || echo "(FAILED)"
+  rm "${GPG_TEST}"_* 2>/dev/null && echo "(OK)" || echo "(FAILED)"
 }
 
 # signing enabled?
@@ -1900,7 +2028,7 @@ if [ ${#GPG_KEYS_ENC_ARRAY[@]} -gt 0 ]; then
   done
   # check encrypting
   CMD_MSG="Test - Encrypt to '$(join "','" "${GPG_KEYS_ENC_ARRAY[@]}")'${CMD_MSG_SIGN:+ & $CMD_MSG_SIGN}"
-  run_cmd $(gpg_pass_pipein GPG_PW_SIGN GPG_PW) $GPG $CMD_PARAM_SIGN $(gpg_param_passwd GPG_PW_SIGN GPG_PW) $CMD_PARAMS $GPG_USEAGENT --status-fd 1 $GPG_OPTS -o "${GPG_TEST}_ENC" -e "$ME_LONG"
+  run_cmd $(gpg_pass_pipein GPG_PW_SIGN GPG_PW) gpg $CMD_PARAM_SIGN $(gpg_param_passwd GPG_PW_SIGN GPG_PW) $CMD_PARAMS $GPG_USEAGENT --status-fd 1 $GPG_OPTS -o $(qw "${GPG_TEST}_ENC") -e $(qw "$ME_LONG")
   CMD_ERR=$?
 
   if [ "$CMD_ERR" != "0" ]; then
@@ -1914,7 +2042,7 @@ if [ ${#GPG_KEYS_ENC_ARRAY[@]} -gt 0 ]; then
   # check decrypting
   CMD_MSG="Test - Decrypt"
   gpg_key_decryptable || CMD_DISABLED="No matching secret key available."
-  run_cmd $(gpg_pass_pipein GPG_PW) "$GPG" $(gpg_param_passwd GPG_PW) $GPG_OPTS -o "${GPG_TEST}_DEC" $GPG_USEAGENT -d "${GPG_TEST}_ENC"
+  run_cmd $(gpg_pass_pipein GPG_PW) gpg $(gpg_param_passwd GPG_PW) $GPG_OPTS -o $(qw "${GPG_TEST}_DEC") $GPG_USEAGENT -d $(qw "${GPG_TEST}_ENC")
   CMD_ERR=$?
 
   if [ "$CMD_ERR" != "0" ]; then
@@ -1925,7 +2053,7 @@ if [ ${#GPG_KEYS_ENC_ARRAY[@]} -gt 0 ]; then
 else
   # check encrypting
   CMD_MSG="Test - Encryption with passphrase${CMD_MSG_SIGN:+ & $CMD_MSG_SIGN}"
-  run_cmd $(gpg_pass_pipein GPG_PW) "$GPG" $GPG_OPTS $CMD_PARAM_SIGN --passphrase-fd 0 -o "${GPG_TEST}_ENC" --batch -c "$ME_LONG"
+  run_cmd $(gpg_pass_pipein GPG_PW) gpg $GPG_OPTS $CMD_PARAM_SIGN --passphrase-fd 0 -o $(qw "${GPG_TEST}_ENC") --batch -c $(qw "$ME_LONG")
   CMD_ERR=$?
   if [ "$CMD_ERR" != "0" ]; then
     error_gpg_test "Encryption failed.${CMD_OUT:+\n$CMD_OUT}"
@@ -1933,7 +2061,7 @@ else
 
   # check decrypting
   CMD_MSG="Test - Decryption with passphrase"
-  run_cmd $(gpg_pass_pipein GPG_PW) "$GPG" $GPG_OPTS --passphrase-fd 0 -o "${GPG_TEST}_DEC" --batch -d "${GPG_TEST}_ENC"
+  run_cmd $(gpg_pass_pipein GPG_PW) gpg $GPG_OPTS --passphrase-fd 0 -o $(qw "${GPG_TEST}_DEC") --batch -d $(qw "${GPG_TEST}_ENC")
   CMD_ERR=$?
   if [ "$CMD_ERR" != "0" ]; then
     error_gpg_test "Decryption failed.${CMD_OUT:+\n$CMD_OUT}"
@@ -1974,104 +2102,62 @@ var_isset 'TARGET_URL_PASS' && TARGET_URL_PASS="$(url_decode "$TARGET_URL_PASS")
 var_isset 'TARGET_USER' && TARGET_URL_USER="$TARGET_USER"
 var_isset 'TARGET_PASS' && TARGET_URL_PASS="$TARGET_PASS"
 
-# build target backend data depending on protocol
+# issue some warnings
 case "$(tolower "${TARGET_URL_PROT%%:*}")" in
-  's3'|'s3+http')
-    BACKEND_PARAMS="AWS_ACCESS_KEY_ID='${TARGET_URL_USER}' AWS_SECRET_ACCESS_KEY='${TARGET_URL_PASS}'"
-    BACKEND_URL="${TARGET_URL_PROT}${TARGET_URL_HOSTPATH}"
-    ;;
-  'gs')
-    BACKEND_PARAMS="GS_ACCESS_KEY_ID='${TARGET_URL_USER}' GS_SECRET_ACCESS_KEY='${TARGET_URL_PASS}'"
-    BACKEND_URL="${TARGET_URL_PROT}${TARGET_URL_HOSTPATH}"
-    ;;
   'cf+http')
-    # respect potentially set cloudfile env vars
-    var_isset 'CLOUDFILES_USERNAME' && TARGET_URL_USER="$CLOUDFILES_USERNAME"
-    var_isset 'CLOUDFILES_APIKEY' && TARGET_URL_PASS="$CLOUDFILES_APIKEY"
-    # add them to duplicity params
-    var_isset 'TARGET_URL_USER' && \
-      BACKEND_PARAMS="CLOUDFILES_USERNAME=$(qw "${TARGET_URL_USER}")"
-    var_isset 'TARGET_URL_PASS' && \
-      BACKEND_PARAMS="$BACKEND_PARAMS CLOUDFILES_APIKEY=$(qw "${TARGET_URL_PASS}")"
-    BACKEND_URL="${TARGET_URL_PROT}${TARGET_URL_HOSTPATH}"
     # info on missing AUTH_URL
     if ! var_isset 'CLOUDFILES_AUTHURL'; then
-      echo -e "INFO: No CLOUDFILES_AUTHURL defined (in conf).\n      Will use default from python-cloudfiles (probably rackspace)."
-    else
-      BACKEND_PARAMS="$BACKEND_PARAMS CLOUDFILES_AUTHURL=$(qw "${CLOUDFILES_AUTHURL}")"
+      inform "No CLOUDFILES_AUTHURL exported (in conf).
+Will use default which is probably rackspace."
     fi
     ;;
-   'file'|'tahoe'|'dpbx')
-     BACKEND_URL="${TARGET_URL_PROT}${TARGET_URL_HOSTPATH}"
-     ;;
    'swift')
-     BACKEND_URL="${TARGET_URL_PROT}${TARGET_URL_HOSTPATH}"
-     # respect possibly set swift env vars
-     var_isset 'SWIFT_USERNAME' && TARGET_URL_USER="$SWIFT_USERNAME"
-     var_isset 'SWIFT_PASSWORD' && TARGET_URL_PASS="$SWIFT_PASSWORD"
-     # add them to duplicity params like with cloudfile to make it look standardized
-     var_isset 'TARGET_URL_USER' && \
-       BACKEND_PARAMS="$BACKEND_PARAMS SWIFT_USERNAME=$(qw "${TARGET_URL_USER}")"
-     var_isset 'SWIFT_AUTHURL' && \
-       BACKEND_PARAMS="$BACKEND_PARAMS SWIFT_AUTHURL=$(qw "${SWIFT_AUTHURL}")"
-     ( var_isset 'TARGET_URL_USER' && ! var_isset 'SWIFT_AUTHURL' ) &&\
+    # info on possibly missing AUTH_URL
+       var_isset 'SWIFT_AUTHURL' ||\
        warning "\
-Swift will probably fail because the conf var SWIFT_AUTHURL was not defined!"
-     var_isset 'SWIFT_TENANTNAME' && \
-       BACKEND_PARAMS="$BACKEND_PARAMS SWIFT_TENANTNAME=$(qw "${SWIFT_TENANTNAME}")"
-     var_isset 'SWIFT_AUTHVERSION' && \
-       BACKEND_PARAMS="$BACKEND_PARAMS SWIFT_AUTHVERSION=$(qw "${SWIFT_AUTHVERSION}")"
-     var_isset 'TARGET_URL_PASS' && \
-       BACKEND_PARAMS="$BACKEND_PARAMS SWIFT_PASSWORD=$(qw "${TARGET_URL_PASS}")"
-     ;;
+Swift will probably fail because the conf var SWIFT_AUTHURL was not exported!"
+    ;;
   'rsync')
     # everything in url (this backend does not support pass in env var)
     # this is obsolete from version 0.6.10 (buggy), hopefully fixed in 0.6.11
     # print warning older version is detected
-    var_isset 'TARGET_URL_USER' && BACKEND_CREDS="$(url_encode "${TARGET_URL_USER}")"
-    if duplicity_version_lt 610; then
+    duplicity_version_lt 610 &&
       warning "\
 Duplicity version '$DUPL_VERSION' does not support providing the password as
 env var for rsync backend. For security reasons you should consider to
 update to a version greater than '0.6.10' of duplicity."
-      var_isset 'TARGET_URL_PASS' && BACKEND_CREDS="${BACKEND_CREDS}:$(url_encode "${TARGET_URL_PASS}")"
-    else
-      var_isset 'TARGET_URL_PASS' && BACKEND_PARAMS="FTP_PASSWORD=$(qw "${TARGET_URL_PASS}")"
-    fi
-    var_isset 'BACKEND_CREDS' && BACKEND_CREDS="${BACKEND_CREDS}@"
-    BACKEND_URL="${TARGET_URL_PROT}${BACKEND_CREDS}${TARGET_URL_HOSTPATH}"
-    ;;
-  *)
-    # for all other protocols we put username in url and pass into env var
-    # for secË™rity reasons, we url_encode username to protect special chars
-    var_isset 'TARGET_URL_USER' &&
-      BACKEND_CREDS="$(url_encode "${TARGET_URL_USER}")@"
-    # sortout backends with special ways to handle password
-    case "$(tolower "${TARGET_URL_PROT%%:*}")" in
-      'imap'|'imaps')
-        var_isset 'TARGET_URL_PASS' && BACKEND_PARAMS="IMAP_PASSWORD=$(qw "${TARGET_URL_PASS}")"
-      ;;
-      'ssh'|'sftp'|'scp')
-        # ssh backend wants to be told that theres a pass to use
-        var_isset 'TARGET_URL_PASS' && \
-          DUPL_PARAMS="$DUPL_PARAMS --ssh-askpass" && \
-          BACKEND_PARAMS="FTP_PASSWORD=$(qw "${TARGET_URL_PASS}")"
-      ;;
-      *)
-        # rest uses FTP_PASS var
-        var_isset 'TARGET_URL_PASS' && \
-          BACKEND_PARAMS="FTP_PASSWORD=$(qw "${TARGET_URL_PASS}")"
-      ;;
-    esac
-    BACKEND_URL="${TARGET_URL_PROT}${BACKEND_CREDS}${TARGET_URL_HOSTPATH}"
     ;;
 esac
+
+
+# for all protocols we put username in url and pass into env var
+# for secúrity reasons, we url_encode username to protect special chars
+# first sortout backends with special ways to handle password
+case "$(tolower "${TARGET_URL_PROT%%:*}")" in
+  'imap'|'imaps')
+    var_isset 'TARGET_URL_PASS' && BACKEND_PARAMS="IMAP_PASSWORD=$(qw "${TARGET_URL_PASS}")"
+    ;;
+  *)
+    # rest uses FTP_PASS var
+    var_isset 'TARGET_URL_PASS' && \
+      BACKEND_PARAMS="FTP_PASSWORD=$(qw "${TARGET_URL_PASS}")"
+    ;;
+esac
+# insert url encoded username into target url if needed
+if var_isset 'TARGET_URL_USER'; then
+  BACKEND_URL="${TARGET_URL_PROT}$(url_encode "${TARGET_URL_USER}")@${TARGET_URL_HOSTPATH}"
+else
+  BACKEND_URL="$TARGET"
+fi
+
 
 # protect eval from special chars in url (e.g. open ')' in password,
 # spaces in path, quotes) happens above in duplify() via quotewrap()
 SOURCE="$SOURCE"
 BACKEND_URL="$BACKEND_URL"
 EXCLUDE="$EXCLUDE"
+# since 0.7.03 --exclude-globbing-filelist is deprecated
+EXCLUDE_PARAM="--exclude$(duplicity_version_lt 703 && echo -globbing)-filelist"
 
 # replace magic separators to condition command equivalents (+=and,-=or)
 cmds=$(awk -v cmds="$cmds" "BEGIN{ gsub(/\+/,\"_and_\",cmds); gsub(/\-/,\"_or_\",cmds); print cmds}")
@@ -2116,14 +2202,16 @@ nextno=$(($CMD_NO+1))
 prevno=$(( $CMD_NO - ${CMD_SKIPPED-0} - 1 )); unset CMD_SKIPPED
 [ "$prevno" -ge 0 ] && CMD_PREV=${CMDS[$prevno]} || CMD_PREV='START'
 
-# export some useful env vars for external scripts/programs to use
-export CONFDIR SOURCE TARGET_URL_PROT TARGET_URL_HOSTPATH \
-       TARGET_URL_USER TARGET_URL_PASS \
-       GPG_KEYS_ENC=$(join "\n" "${GPG_KEYS_ENC_ARRAY[@]}") GPG_KEY_SIGN \
-       GPG_PW CMD_PREV CMD_NEXT CMD_ERR
-
 # save start time
 RUN_START=$(date_fix %s)$(nsecs)
+
+# export some useful env vars for external scripts/programs to use
+export PROFILE CONFDIR SOURCE TARGET_URL_PROT TARGET_URL_HOSTPATH \
+       TARGET_URL_USER TARGET_URL_PASS \
+       GPG_KEYS_ENC=$(join "\n" "${GPG_KEYS_ENC_ARRAY[@]}") GPG_KEY_SIGN \
+       GPG_PW CMD_PREV CMD_NEXT CMD_ERR \
+       RUN_START
+
 # user info
 echo; separator "Start running command $(toupper $cmd) at $(date_from_nsecs $RUN_START)"
 
@@ -2138,20 +2226,20 @@ case "$(tolower $cmd)" in
     ( run_script "$script" )
     ;;
   'bkp')
-    duplify -- "${dupl_opts[@]}" --exclude-globbing-filelist "$EXCLUDE" \
+    duplify -- "${dupl_opts[@]}" $EXCLUDE_PARAM "$EXCLUDE" \
           "$SOURCE" "$BACKEND_URL"
     ;;
   'incr')
-    duplify incr -- "${dupl_opts[@]}" --exclude-globbing-filelist "$EXCLUDE" \
+    duplify incr -- "${dupl_opts[@]}" $EXCLUDE_PARAM "$EXCLUDE" \
           "$SOURCE" "$BACKEND_URL"
     ;;
   'full')
-    duplify full -- "${dupl_opts[@]}" --exclude-globbing-filelist "$EXCLUDE" \
+    duplify full -- "${dupl_opts[@]}" $EXCLUDE_PARAM "$EXCLUDE" \
           "$SOURCE" "$BACKEND_URL"
     ;;
   'verify')
     TIME="${ftpl_pars[0]:+"-t ${ftpl_pars[0]}"}"
-    duplify verify -- $TIME "${dupl_opts[@]}" --exclude-globbing-filelist "$EXCLUDE" \
+    duplify verify -- $TIME "${dupl_opts[@]}" $EXCLUDE_PARAM "$EXCLUDE" \
           "$BACKEND_URL" "$SOURCE"
     ;;
   'verifypath')
@@ -2162,7 +2250,7 @@ case "$(tolower $cmd)" in
   Hint:
     Syntax is -> $ME <profile> verifyPath <rel_bkp_path> <local_path> [<age>]"
 
-    duplify verify -- $TIME "${dupl_opts[@]}" --exclude-globbing-filelist "$EXCLUDE" \
+    duplify verify -- $TIME "${dupl_opts[@]}" $EXCLUDE_PARAM "$EXCLUDE" \
           --file-to-restore "$IN_PATH" "$BACKEND_URL" "$OUT_PATH"
     ;;
   'list')
@@ -2195,13 +2283,13 @@ case "$(tolower $cmd)" in
           -- "${dupl_opts[@]}" "$BACKEND_URL"
     ;;
   'restore')
-    OUT_PATH="${ftpl_pars[0]:-$SOURCE}"; TIME="${ftpl_pars[1]:-now}";
+    OUT_PATH="${ftpl_pars[0]}"; TIME="${ftpl_pars[1]:-now}";
     [ -z "$OUT_PATH" ] && error "  Missing parameter target_path for restore.
 
   Hint:
     Syntax is -> $ME <profile> restore <target_path> [<age>]"
 
-    duplify  -- -t "$TIME" "${dupl_opts[@]}" "$BACKEND_URL" "$OUT_PATH" && run_script $CONFDIR/restore;
+    duplify  -- -t "$TIME" "${dupl_opts[@]}" "$BACKEND_URL" "$OUT_PATH"
     ;;
   'fetch')
     IN_PATH="${ftpl_pars[0]}"; OUT_PATH="${ftpl_pars[1]}";
@@ -2224,7 +2312,8 @@ case "$(tolower $cmd)" in
 esac
 
 CMD_ERR=$?
-RUN_END=$(date_fix %s)$(nsecs) ; RUNTIME=$(( $RUN_END - $RUN_START ))
+RUN_END=$(date_fix %s)$(nsecs)
+RUNTIME=$(( $RUN_END - $RUN_START ))
 
 # print message on error; set error code
 if [ "$CMD_ERR" -ne 0 ]; then


### PR DESCRIPTION
Upgraded duply script to version 2.0.1 which adds some fixes for GPG2 support. This had the negative side-effect of breaking S3 targets so I made some relative changes under the conf templates to export AWS credentials into the environment.

Found some other bugs in duplicity that required me to update to the latest version. Unfortunately `jessie` only had the `0.6` line in their repositories but had the most up-to-date stable releases in `jessie-backports`. Added functionality to allow install duplicity from backports depending on status of optional `backup_modern_duplicty` variable boolean (set to `false` by default).
