### PR TITLE
Add variable for cron file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The role variables and default values.
 backup_enabled: yes             # Enable the role
 backup_remove: no               # Set yes for uninstall the role from target system
 backup_cron: yes                # Setup cron tasks for backup
+backup_cron_filename: backup    # The cron file name for backup tasks. Use it for multiple backup configs on the same server
 
 backup_user: root               # Run backups as user
 backup_group: "{{backup_user}}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 backup_enabled: yes             # Enable the role
 backup_remove: no               # Set yes for uninstall the role from target system
 backup_cron: yes                # Setup cron tasks for backup
+backup_cron_filename: backup    # The cron file name for backup tasks. Use it for multiple backup configs on the same server
 
 backup_user: root               # Run backups as user
 backup_group: "{{backup_user}}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -42,7 +42,7 @@
   with_items: "{{backup_profiles}}"
 
 - name: backup-configure | Setup cron
-  template: src=cron.j2 dest=/etc/cron.d/backup owner=root group=root mode=0644
+  template: src=cron.j2 dest=/etc/cron.d/{{backup_cron_filename}} owner=root group=root mode=0644
   when: backup_cron
 
 - name: backup-configure | Create log files


### PR DESCRIPTION
Hi, i've added a new variable `backup_cron_filename` that can be used to set the cron file name. This way we can split the backups in many playbooks for the same server(s) each with its own cron.